### PR TITLE
Make type in Param optional

### DIFF
--- a/rust.ungram
+++ b/rust.ungram
@@ -146,7 +146,7 @@ SelfParam =
 
 Param =
   Attr* (
-    Pat (':' Type)
+    Pat (':' Type)?
   | Type
   | '...'
   )


### PR DESCRIPTION
I assume that's why there were already parentheses around the `':' Type`?