### PR TITLE
Allow type aliases in extern blocks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ungrammar"
 description = "A DSL for describing concrete syntax trees"
-version = "1.1.2"
+version = "1.1.3"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/matklad/ungrammar"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]

--- a/rust.ungram
+++ b/rust.ungram
@@ -250,6 +250,7 @@ ExternItem =
   Fn
 | MacroCall
 | Static
+| TypeAlias
 
 GenericParamList =
   '<' (GenericParam (',' GenericParam)* ','?)? '>'


### PR DESCRIPTION
This is for the unstable feature https://github.com/rust-lang/rust/issues/43467, which rustc uses internally