### PR TITLE
Move towards upstream `macro_rules!` model

### DIFF
--- a/rust.ungram
+++ b/rust.ungram
@@ -58,7 +58,7 @@ ConstArg =
   Expr
 
 MacroCall =
-  Attr* Path '!' Name? TokenTree ';'?
+  Attr* Path '!' TokenTree ';'?
 
 TokenTree =
   '(' ')'
@@ -89,6 +89,7 @@ Item =
 | Fn
 | Impl
 | MacroCall
+| MacroRules
 | Module
 | Static
 | Struct
@@ -96,6 +97,14 @@ Item =
 | TypeAlias
 | Union
 | Use
+
+MacroRules =
+  Attr* Visibility?
+  'macro_rules' '!' Name
+  '{' MacroArm (';' MacroArm)* ';'? '}'
+
+MacroArm =
+  TokenTree '=>' TokenTree
 
 Module =
   Attr* Visibility?


### PR DESCRIPTION
Upstream Rust has long since considered `macro_rules!` to be an item declaration instead of a macro invocation. Additionally, macro invocations cannot have a "name" between the `path::to::macro!` and the argument token tree.

This PR moves ungrammar closer to that model, and also allows visibility on `MacroRules` items, which has been proposed in https://github.com/rust-lang/rust/pull/78166.