### PR TITLE
Add inline const expression and pattern

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ungrammar"
 description = "A DSL for describing concrete syntax trees"
-version = "1.4.0"
+version = "1.5.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/matklad/ungrammar"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]

--- a/rust.ungram
+++ b/rust.ungram
@@ -372,13 +372,13 @@ BlockExpr =
   '}'
 
 RefExpr =
-  Attr* '&' ('raw' |'mut' | 'const') Expr
+  Attr* '&' ('raw' | 'mut' | 'const') Expr
 
 TryExpr =
   Attr* Expr '?'
 
 EffectExpr =
-  Attr* Label? ('try' | 'unsafe' | 'async') BlockExpr
+  Attr* Label? ('try' | 'unsafe' | 'async' | 'const') BlockExpr
 
 PrefixExpr =
   Attr* op:('-' | '!' | '*') Expr
@@ -582,6 +582,7 @@ Pat =
 | SlicePat
 | TuplePat
 | TupleStructPat
+| ConstBlockPat
 
 LiteralPat =
   Literal
@@ -636,3 +637,6 @@ RestPat =
 
 MacroPat =
   MacroCall
+
+ConstBlockPat =
+  'const' BlockExpr


### PR DESCRIPTION
To be able to address https://github.com/rust-analyzer/rust-analyzer/issues/6848 in the (near) future. The name `ConstBlockPattern` was chosen since that's what the [rfc](https://rust-lang.github.io/rfcs/2920-inline-const.html) calls it.

CodeGen with this breaks RA in one file https://github.com/rust-analyzer/rust-analyzer/blob/master/crates/hir_def/src/body/lower.rs#L825, that is if the `"CONST_BLOCK_PAT"` has been added to KINDS_SRC.

I figure adding this now is a good time as the rust.ungrammar is being changed for lifetimes and macros2.0 anyways.