### PR TITLE
Split out macro calls in item position

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ungrammar"
 description = "A DSL for describing concrete syntax trees"
-version = "1.11.0"
+version = "1.12.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/matklad/ungrammar"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]

--- a/rust.ungram
+++ b/rust.ungram
@@ -90,7 +90,7 @@ Item =
 | ExternCrate
 | Fn
 | Impl
-| MacroCall
+| MacroItem
 | MacroRules
 | MacroDef
 | Module
@@ -100,6 +100,9 @@ Item =
 | TypeAlias
 | Union
 | Use
+
+MacroItem =
+  MacroCall
 
 MacroRules =
   Attr* Visibility?


### PR DESCRIPTION
This is needed in order to distinguish macro calls in expression position from calls in item position.

Required for https://github.com/rust-analyzer/rust-analyzer/issues/7717.