### PR TITLE
Macro Statements should be also an Expr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ungrammar"
 description = "A DSL for describing concrete syntax trees"
-version = "1.12.1"
+version = "1.12.2"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/matklad/ungrammar"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]

--- a/rust.ungram
+++ b/rust.ungram
@@ -339,6 +339,7 @@ Expr =
 | Literal
 | LoopExpr
 | MacroCall
+| MacroStmts
 | MatchExpr
 | MethodCallExpr
 | ParenExpr


### PR DESCRIPTION
e.g: 

```rust
macro_rules! identity { ($($es:tt)*) => { $($es)* } }

fn main() -> usize { 
  identity! { let _ = (); }   //  statements
  identity! { let _ = (); 0 }   // expr, return 0
}
```