### PR TITLE
Report 1-based indices in Error's Display impl

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -16,7 +16,8 @@ pub struct Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(loc) = self.location {
-            write!(f, "{}:{}: ", loc.line, loc.column)?
+            // Report 1-based indices, to match text editors
+            write!(f, "{}:{}: ", loc.line + 1, loc.column + 1)?
         }
         write!(f, "{}", self.message)
     }


### PR DESCRIPTION
This matches every (mainstream) text editor's use of the line:column format.

I actually lost some time trying to figure out why it was complaining about an empty line before I realized why 😅

I kept `Location` 0-based and translated just at the point of display, as that was a much less invasive change.