### PR TITLE
Add a `Meta` node representing attribute contents

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ungrammar"
 description = "A DSL for describing concrete syntax trees"
-version = "1.13.0"
+version = "1.14.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/matklad/ungrammar"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]

--- a/rust.ungram
+++ b/rust.ungram
@@ -298,7 +298,10 @@ Visibility =
   'pub' ('(' 'in'? Path ')')?
 
 Attr =
-  '#' '!'? '[' Path ('=' Expr | TokenTree)? ']'
+  '#' '!'? '[' Meta ']'
+
+Meta =
+  Path ('=' Expr | TokenTree)?
 
 //****************************//
 // Statements and Expressions //


### PR DESCRIPTION
The main motivation of this change is to make attribute handling easier: `#[cfg_attr]` can expand to an arbitrary nested list of attributes, and we currently just format those with `#[{}]` and parse that, which loses the assigned `TokenId`s. The `TokenId`s will be needed later to uniquely identify attributes that come from `cfg_attr`.

With this change, we can instead use `mbe::token_tree_to_syntax_node` to parse the tokens into a `FragmentKind::MetaItem`, which returns a `ast::Meta` node, and process that.