### PR TITLE
Allow leading pipe for rules with >1 production

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,3 +135,20 @@ fn smoke() {
 fn test_rust_grammar() {
     let _ = rust_grammar();
 }
+
+#[test]
+#[should_panic]
+fn leading_pipe_bad() {
+    let grammar = "
+    Name = | 'ident' | 'self'
+    Bad = | 'asdf' 'hjkl' ";
+    let _ = grammar.parse::<Grammar>().unwrap();
+}
+
+#[test]
+fn leading_pipe_ok() {
+    let grammar = "
+    Name = | 'ident' | 'self'
+    Ok = 'asdf' 'hjkl' ";
+    let _ = grammar.parse::<Grammar>().unwrap();
+}


### PR DESCRIPTION
It's not uncommon for EBNF (or just patterns using `|` for alternation)
to allow a leading pipe. Ungram currently does not allow this; the
current behavior is to fail and return a generic parse error.

This change allows the use of a leading pipe for rules that have
more than one production/RHS. For example, this would now be valid:

```
A ::=
  | 'tok1'
  | 'tok2'
```