### PR TITLE
More specific error for leading pipes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ungrammar"
 description = "A DSL for describing concrete syntax trees"
-version = "1.14.0"
+version = "1.14.1"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/matklad/ungrammar"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -109,6 +109,14 @@ fn node(p: &mut Parser) -> Result<()> {
 }
 
 fn rule(p: &mut Parser) -> Result<Rule> {
+    if let Some(lexer::Token { kind: TokenKind::Pipe, loc }) = p.peek() {
+        bail!(
+            *loc,
+            "The first element in a sequence of productions or alternatives \
+            must not have a leading pipe (`|`)"
+        );
+    }
+
     let lhs = seq_rule(p)?;
     let mut alt = vec![lhs];
     while let Some(token) = p.peek() {


### PR DESCRIPTION
Re: #34; return a more detailed error message when counting an improperly placed leading pipe.