### PR TITLE
Add both variants of half open range patterns to the grammar

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,9 @@
 [package]
 name = "ungrammar"
 description = "A DSL for describing concrete syntax trees"
-version = "1.14.3"
+version = "1.14.4"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/matklad/ungrammar"
-authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 edition = "2018"
 
 exclude = ["/bors.toml", "/.github"]

--- a/rust.ungram
+++ b/rust.ungram
@@ -603,7 +603,12 @@ WildcardPat =
   '_'
 
 RangePat =
-  start:Pat op:('..' | '..=') end:Pat
+  // 1..
+  start:Pat op:('..' | '..=')
+  // 1..2
+  | start:Pat op:('..' | '..=') end:Pat
+  // ..2
+  | op:('..' | '..=') end:Pat
 
 RefPat =
   '&' 'mut'? Pat


### PR DESCRIPTION
This is prompted by
https://github.com/rust-analyzer/rust-analyzer/issues/9779, but it
is not actually a prerequisite of making that one happen as this commit
doesn't change the generated code on the r-a side.

Relevant PR (that does not require this one be merged immediately/a release made): https://github.com/rust-analyzer/rust-analyzer/pull/9780