### PR TITLE
Support if- and while-let chains

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ungrammar"
 description = "A DSL for describing concrete syntax trees"
-version = "1.14.9"
+version = "1.15.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/matklad/ungrammar"
 edition = "2018"

--- a/rust.ungram
+++ b/rust.ungram
@@ -357,6 +357,7 @@ Expr =
 | TupleExpr
 | WhileExpr
 | YieldExpr
+| LetExpr
 
 Literal =
   Attr* value:(
@@ -448,12 +449,8 @@ ClosureExpr =
   body:Expr
 
 IfExpr =
-  Attr* 'if' Condition then_branch:BlockExpr
+  Attr* 'if' condition:Expr then_branch:BlockExpr
   ('else' else_branch:(IfExpr | BlockExpr))?
-
-Condition =
-  'let' Pat '=' Expr
-| Expr
 
 LoopExpr =
   Attr* Label? 'loop'
@@ -464,7 +461,7 @@ ForExpr =
   loop_body:BlockExpr
 
 WhileExpr =
-  Attr* Label? 'while' Condition
+  Attr* Label? 'while' condition:Expr
   loop_body:BlockExpr
 
 Label =
@@ -492,13 +489,16 @@ MatchArm =
   Attr* Pat guard:MatchGuard? '=>' Expr ','?
 
 MatchGuard =
-  'if' ('let' Pat '=')? Expr
+  'if' condition:Expr
 
 ReturnExpr =
   Attr* 'return' Expr?
 
 YieldExpr =
   Attr* 'yield' Expr?
+
+LetExpr =
+  Attr* 'let' Pat '=' Expr
 
 AwaitExpr =
   Attr* Expr '.' 'await'


### PR DESCRIPTION
RFC 2497 https://github.com/rust-lang/rfcs/blob/master/text/2497-if-let-chains.md.

I'm not sure if this should be a major or minor version bump: it breaks users of rust.ungram but not general users of the crate.