### PR TITLE
Revert the visibility removal of macro_rules visibility (#46)

### DIFF
--- a/rust.ungram
+++ b/rust.ungram
@@ -102,7 +102,7 @@ Item =
 | Use
 
 MacroRules =
-  Attr*
+  Attr* Visibility?
   'macro_rules' '!' Name
   TokenTree
 


### PR DESCRIPTION
As discussed in https://github.com/rust-analyzer/ungrammar/pull/46#issuecomment-1049758027.