### PR TITLE
Include `Self` specifically in NameRef

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ungrammar"
 description = "A DSL for describing concrete syntax trees"
-version = "1.16.0"
+version = "1.16.1"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/matklad/ungrammar"
 edition = "2018"

--- a/rust.ungram
+++ b/rust.ungram
@@ -24,7 +24,7 @@ Name =
   'ident' | 'self'
 
 NameRef =
-  'ident' | 'int_number' | 'self' | 'super' | 'crate'
+  'ident' | 'int_number' | 'self' | 'super' | 'crate' | 'Self'
 
 Lifetime =
   'lifetime_ident'


### PR DESCRIPTION
`Self` is a keyword, so we'll treat it as such
bors r+