### PR TITLE
Update ungrammar.ungram with proper labeled rule

### DIFF
--- a/ungrammar.ungram
+++ b/ungrammar.ungram
@@ -13,4 +13,4 @@ Rule =
 | Rule '?'
 | Rule '*'
 | '(' Rule ')'
-| label:'ident' ':'
+| label:'ident' ':' Rule


### PR DESCRIPTION
Labels are followed by rules

The ungrammar listed in https://rust-analyzer.github.io/blog/2020/10/24/introducing-ungrammar.html seems to be correct