### PR TITLE
implement `Clone` for `Rule`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ pub struct TokenData {
 }
 
 /// A production rule.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Rule {
     /// A labeled rule, like `a:B` (`"a"` is the label, `B` is the rule).
     Labeled {


### PR DESCRIPTION
My use case for this is being able to convert `r: &Rule` into `Rule::Seq(vec![r.clone()])`, so that I can share logic for nodes with 1 field and sequence nodes.